### PR TITLE
feat: ✨ add spaPageview support

### DIFF
--- a/src/helpers/get-zaraz.ts
+++ b/src/helpers/get-zaraz.ts
@@ -1,5 +1,5 @@
 type QueueItem = {
-  method: 'track' | 'set' | 'ecommerce';
+  method: 'track' | 'set' | 'ecommerce' | 'spaPageview';
   arguments: unknown;
 };
 
@@ -28,6 +28,9 @@ export function getZaraz() {
       },
       ecommerce: (...args: unknown[]) => {
         queue.push({ method: 'ecommerce', arguments: args });
+      },
+      spaPageview: (...args: unknown[]) => {
+        queue.push({ method: 'spaPageview', arguments: args });
       },
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { ecommerce } from './ecommerce';
 import { set } from './set';
+import { spaPageview } from './spa-pageview';
 import { track } from './track';
 
 declare global {
@@ -15,9 +16,11 @@ export const zaraz = {
   track,
   set,
   ecommerce,
+  spaPageview,
 };
 
 // Export typing etc.
 export * from './ecommerce';
 export * from './set';
+export * from './spa-pageview';
 export * from './track';

--- a/src/spa-pageview.spec.ts
+++ b/src/spa-pageview.spec.ts
@@ -1,0 +1,38 @@
+import { spaPageview } from './spa-pageview';
+
+const trackMock = jest.fn();
+const setMock = jest.fn();
+const ecommerceMock = jest.fn();
+const spaPageviewMock = jest.fn();
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    zaraz: any;
+  }
+}
+
+let windowObj: Window & typeof globalThis;
+
+beforeAll(() => {
+  windowObj = window;
+});
+
+afterAll(() => {
+  window = windowObj;
+});
+
+describe('set()', () => {
+  it('should call zaraz spaPageview when called', () => {
+    window.zaraz = {
+      track: trackMock,
+      set: setMock,
+      ecommerce: ecommerceMock,
+      spaPageview: spaPageviewMock,
+    };
+
+    spaPageview();
+
+    expect(spaPageviewMock).toHaveBeenCalledWith();
+  });
+});

--- a/src/spa-pageview.ts
+++ b/src/spa-pageview.ts
@@ -1,0 +1,6 @@
+import { getZaraz } from './helpers/get-zaraz';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function spaPageview(): void {
+  getZaraz().spaPageview();
+}


### PR DESCRIPTION
This PR adds support for the new `spaPageview` method. It can be used to manually trigger a pageview without having to access Zaraz internals like `zarazData.l`, `zarazData.t`, or `zaraz.__zarazMCListeners`.

> `spaPageview` is not yet officially documented by Cloudflare.